### PR TITLE
Set FIRESTORE_PROJECT_ID = dummy-project-id

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "dummy-project"
+    "default": "dummy-project-id"
   }
 }

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ COPY . .
 RUN chmod 755 entrypoint.sh
 
 ENV FIRESTORE_PORT 8080
+ENV FIRESTORE_PROJECT_ID "dummy-firestore-id"
 ENV UI_PORT 4000
 
 EXPOSE "$UI_PORT"


### PR DESCRIPTION
Set the FIRESTORE_PROJECT_ID to "dummy-project-id", as opposed to "dummy-project"

Set a default env var for FIRESTORE_PROJECT_ID = "dummy-project-id" in the Dockerfile